### PR TITLE
✨ feature : 광고주/ 인플루언서 엔티티 초기 세팅 완료

### DIFF
--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Advertiser.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Advertiser.java
@@ -1,0 +1,45 @@
+package com.Gritty.Linki.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+  * 광고주 엔티티
+  */
+ @Entity
+ @Table(name = "advertiser")
+ @Getter
+ @Setter
+ @NoArgsConstructor(access = AccessLevel.PROTECTED)
+ public class Advertiser {
+    
+    @Id
+      @Column(name = "advertiser_id", length = 25)  private String advertiserId;
+    
+   @Column(name = "business_number", length = 20, nullable = false)
+  private String businessNumber;
+    
+  @Column(name = "company_name", length = 30, nullable = false)
+  private String companyName;
+    
+     // 연관관계 매핑
+     @OneToOne(fetch = FetchType.LAZY)
+   @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    // 광고주와 캠페인 다대일 관계. 캠페인 삭제 시 광고주 삭제되지 않음.
+    @OneToMany(mappedBy = "advertiser", cascade = CascadeType.ALL)
+    private List<Campaign> campaigns = new ArrayList<>();
+    
+    // 광고주와 리다이렉트 링크 일대다 관계. 리다이렉트 링크 삭제 시 광고주 삭제되지 않음.
+     @OneToMany(mappedBy = "advertiser", cascade = CascadeType.ALL)
+     private List<RedirectLinks> redirectLinks = new ArrayList<>();
+    
+
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/AdvertiserReview.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/AdvertiserReview.java
@@ -1,0 +1,36 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "advertiser_review")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdvertiserReview {
+    @Id
+    @Column(name = "advertiser_review_id", nullable = false, length = 255)
+    private String advertiserReviewId;
+
+    @Column(name = "advertiser_review_score", nullable = false, precision = 2, scale = 1)
+    private BigDecimal advertiserReviewScore;
+
+    @Column(name = "advertiser_review_comment", columnDefinition = "TEXT")
+    private String advertiserReviewComment;
+
+    @Column(name = "advertiser_review_created_at", nullable = false)
+    private LocalDateTime advertiserReviewCreatedAt;
+
+    @Column(name = "visibility", nullable = false)
+    private Boolean visibility = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id", nullable = false)
+    private Contract contract;
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Campaign.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Campaign.java
@@ -1,0 +1,72 @@
+package com.Gritty.Linki.entity;
+
+import com.Gritty.Linki.vo.enums.CampaignPublishStatus;
+import com.Gritty.Linki.vo.enums.Category;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "campaign")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 본 생성자는 protected 접근 제어자로 생성됨 (JPA에서 프록시 등을 위해 필요)
+@AllArgsConstructor
+@Builder
+public class Campaign {
+
+    // 캠페인 고유 식별자. null 불가.
+    @Id
+    @Column(name = "campaign_id", length = 25)
+    private String campaignId;
+
+    // 캠페인 이름. null 불가.
+    @Column(name = "campaign_name", length = 100, nullable = false)
+    private String campaignName;
+
+    // 캠페인 설명. null 불가.
+    @Column(name = "campaign_desc", columnDefinition = "LONGTEXT")
+    private String campaignDesc;
+
+    // 캠페인 조건. null 가능
+    @Column(name = "campaign_condition", columnDefinition = "LONGTEXT")
+    private String campaignCondition;
+
+    // 이미지 URL 혹은 base64. null 불가.
+    @Column(name = "campaign_img", columnDefinition = "LONGTEXT", nullable = false)
+    private String campaignImg;
+
+    // 캠페인 (등록)생성 시간. 자동 생성됨. null 불가.
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    // 캠페인 마감 시간. null 불가.
+    @Column(name = "campaign_deadline", nullable = false)
+    private LocalDateTime campaignDeadline;
+
+    // 열거형 상태 (문자열로 저장). 공개 여부.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "campaign_publish_status")
+    private CampaignPublishStatus campaignPublishStatus;
+
+    // 캠페인 카테고리. null 불가.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "campaign_category", nullable = false)
+    private Category campaignCategory;
+
+    // 연관관계 매핑
+    // Advertiser와 다대일 관계. 지연 로딩 사용. null 불가.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "advertiser_id", nullable = false)
+    private Advertiser advertiser;
+
+    // Proposal와 일대다 관계. 캠페인 삭제 시 모든 제안서 삭제.
+    @OneToMany(mappedBy = "campaign", cascade = CascadeType.ALL)
+    private List<Proposal> proposals = new ArrayList<>();
+
+
+
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Channel.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Channel.java
@@ -1,0 +1,86 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 채널 엔티티
+ */
+@Entity
+@Table(name = "channel")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+
+public class Channel {
+
+    // 채널 고유 식별자. null 불가.
+    @Id
+    @Column(name = "channel_id", length = 25)
+    private String channelId;
+
+    // 채널 이름. null 불가.
+    @Column(name = "channel_name", length = 255, nullable = false)
+    private String channelName;
+
+    // 채널 유튜브 아이디. null 불가.
+    @Column(name = "youtube_channel_id", length = 255, nullable = false)
+    private String youtubeChannelId;
+
+    // 채널 URL. null 불가.
+    @Column(name = "channel_url", length = 255, nullable = false)
+    private String channelUrl;
+
+    // 채널 카테고리. null 불가.
+    @Column(name = "channel_category", length = 100, nullable = false)
+    private String channelCategory;
+
+    // 채널 국가. null 불가.
+    @Column(name = "channel_country", length = 100, nullable = false)
+    private String channelCountry;
+
+    @Column(name = "channel_description", columnDefinition = "LONGTEXT")
+    private String channelDescription;
+
+    @Column(name = "channel_thumbnail_url", length = 500)
+    private String channelThumbnailUrl;
+
+    @Column(name = "subscriber_count")
+    private Long subscriberCount;
+
+    @Column(name = "video_count")
+    private Integer videoCount;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+
+    // 채널 배너 URL - JSON 직렬화에만 포함되고 DB에는 저장되지 않음
+    @Transient
+    private String channelBannerUrl;
+
+    @Column(name = "collected_at", nullable = false, updatable = false)
+    private LocalDateTime collectedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "influencer_id", nullable = false)
+    private Influencer influencer;
+
+    @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL)
+    private List<ChannelStats> channelStats = new ArrayList<>();
+
+    @OneToOne(mappedBy = "channel", cascade = CascadeType.ALL)
+    private InfluencerAuth influencerAuth;
+
+    @PrePersist
+    public void prePersist() {
+        this.collectedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/ChannelStats.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/ChannelStats.java
@@ -1,0 +1,44 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_stats")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChannelStats {
+
+    @Id
+    @Column(name = "stats_id", length = 25)
+    private String statsId;
+
+    @Column(name = "subscriber_count")
+    private Integer subscriberCount;
+
+    @Column(name = "num_of_videos")
+    private Integer numOfVideos;
+
+    @Column(name = "views_per_video")
+    private Integer viewsPerVideo;
+
+    @Column(name = "data_fetched_at", nullable = false)
+    private LocalDateTime dataFetchedAt;
+
+    @Column(name = "likes_per_video")
+    private Integer likesPerVideo;
+
+    @Column(name = "comments_per_video")
+    private Integer commentsPerVideo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+
+
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Contract.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Contract.java
@@ -1,0 +1,71 @@
+package com.Gritty.Linki.entity;
+
+import com.Gritty.Linki.vo.enums.ContractStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "contract")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Contract {
+    @Id
+    @Column(name = "contract_id", length = 25, nullable = false)
+    private String contractId; // 계약 ID
+
+    @Column(name = "contract_title", length = 255, nullable = false)
+    private String contractTitle; // 계약 제목
+
+    @Column(name = "document_id", length = 100, nullable = false)
+    private String documentId; // 유캔사인 문서 ID
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contract_status", nullable = false)
+    private ContractStatus contractStatus; // 계약 상태 (PENDING_SIGN, COMPLETED, ONGOING)
+
+    @Column(name = "contract_start_date", nullable = false)
+    private LocalDate contractStartDate; // 캠페인 시작일
+
+    @Column(name = "contract_end_date", nullable = false)
+    private LocalDate contractEndDate; // 캠페인 종료일
+
+    @Column(name = "contract_amount", precision = 15, scale = 2, nullable = false)
+    private BigDecimal contractAmount; // 계약 금액
+
+    @Column(name = "contract_created_at", nullable = false, updatable = false)
+    private LocalDateTime contractCreatedAt; // 계약서 생성 시간
+
+    @Column(name = "contract_completed_at")
+    private LocalDateTime contractCompletedAt; // 계약서 완료 시간
+
+    @Column(name = "contract_payment_date")
+    private LocalDate contractPaymentDate; // 지급 날짜
+
+    @Column(name = "contract_special_terms", columnDefinition = "TEXT")
+    private String contractSpecialTerms; // 특약 사항
+
+    @Column(name = "pdf_file_path", length = 255)
+    private String pdfFilePath; // PDF 문서 경로
+
+    @Column(name = "ad_delivery_status")
+    private Boolean adDeliveryStatus; // 광고 이행 여부
+
+    @Column(name = "event_type", length = 20)
+    private String eventType; // 유캔사인 이벤트 타입
+
+    @Column(name = "document_name", length = 50)
+    private String documentName; // 유캔사인 문서 이름
+
+    // 연관 관계
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "proposal_id", nullable = false)
+    private Proposal proposal; // 제안서
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Influencer.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Influencer.java
@@ -1,0 +1,23 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "influencer")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Influencer {
+    @Id
+    @Column(name = "influencer_id", length = 25, nullable = false)
+    private String influencerId; // 인플루언서 식별 ID
+
+    @Column(name = "user_id", length = 25, nullable = false)
+    private String userId; // 일반 유저 테이블과 연동되는 회원 ID (UUID or 소셜 PK)
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/InfluencerAuth.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/InfluencerAuth.java
@@ -1,0 +1,32 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "influencer_auth")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class InfluencerAuth {
+    @Id
+    @Column(name = "inf_auth_id", length = 25, nullable = false)
+    private String infAuthId; // 인증 고유 ID
+
+    @Column(name = "inf_auth_token")
+    private String infAuthToken; // 인증 토큰 (nullable)
+
+    @Column(name = "inf_auth_email")
+    private String infAuthEmail; // 인증 이메일 (nullable)
+
+    @Column(name = "inf_auth_date")
+    private LocalDateTime infAuthDate; // 인증 일시
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel; // 연관 채널
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/InfluencerReview.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/InfluencerReview.java
@@ -1,0 +1,39 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "influencer_review")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class InfluencerReview {
+
+    @Id
+    @Column(name = "influencer_review_id", length = 25)
+    private String influencerReviewId;
+
+    @Column(name = "influencer_review_score",  nullable = false, precision = 2, scale = 1)
+    private BigDecimal influencerReviewScore;
+
+    @Column(name = "influencer_review_comment", columnDefinition = "TEXT")
+    private String influencerReviewComment;
+
+    @Column(name = "influencer_review_created_at")
+    private LocalDateTime influencerReviewCreatedAt;
+
+    @Column(name = "visibility", nullable = false)
+    private Boolean visibility = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id", nullable = false)
+    private Contract contract;
+
+
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Proposal.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Proposal.java
@@ -1,0 +1,43 @@
+package com.Gritty.Linki.entity;
+
+
+import com.Gritty.Linki.vo.enums.ProposalStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "proposal")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Proposal {
+    @Id
+    @Column(name = "proposal_id", length = 25, nullable = false)
+    private String proposalId; // 제안서 식별 ID
+
+    @Column(name = "contents", columnDefinition = "LONGTEXT")
+    private String contents; // 제안 내용
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ProposalStatus status; // 제안 상태 (PENDING, ACCEPTED, REJECTED)
+
+    @Column(name = "submitted_at", nullable = false)
+    private LocalDateTime submittedAt; // 제안 제출 시점
+
+    @Column(name = "responded_at")
+    private LocalDateTime respondedAt; // 광고주 응답 시점
+
+    // 🔗 연관 관계
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "influencer_id", nullable = false)
+    private Influencer influencer; // 제안자 (인플루언서)
+
+    @Column(name = "campaign_id", length = 25, nullable = false)
+    private String campaignId; // 캠페인 ID (연결 테이블 없으면 직접 ID로만 처리)
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Proposal.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Proposal.java
@@ -38,6 +38,7 @@ public class Proposal {
     @JoinColumn(name = "influencer_id", nullable = false)
     private Influencer influencer; // 제안자 (인플루언서)
 
-    @Column(name = "campaign_id", length = 25, nullable = false)
-    private String campaignId; // 캠페인 ID (연결 테이블 없으면 직접 ID로만 처리)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "campaign_id", nullable = false)
+    private Campaign campaign;
 }

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectClick.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectClick.java
@@ -1,0 +1,27 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name= "redirect_click")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+public class RedirectClick {
+    @Id
+    @Column(name = "click_id", length = 25, nullable = false)
+    private String clickId; // 클릭 ID
+
+    @Column(name = "click_time", nullable = false)
+    private LocalDateTime clickTime; // 클릭 시각
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "redirect_id", nullable = false)
+    private RedirectLink redirectLink; // 어떤 리디렉션 링크에 대한 클릭인지
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectClick.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectClick.java
@@ -23,5 +23,5 @@ public class RedirectClick {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "redirect_id", nullable = false)
-    private RedirectLink redirectLink; // 어떤 리디렉션 링크에 대한 클릭인지
+    private RedirectLinks redirectLink; // 어떤 리디렉션 링크에 대한 클릭인지
 }

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectLink.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectLink.java
@@ -1,0 +1,31 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "redirect_links")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+public class RedirectLink {
+    @Id
+    @Column(name = "redirect_id", length = 25, nullable = false)
+    private String redirectId; // 리디렉션 링크 ID
+
+    @Column(name = "origin_url", columnDefinition = "LONGTEXT", nullable = false)
+    private String originUrl; // 원본 URL
+
+    @Column(name = "redirected_url", columnDefinition = "LONGTEXT", nullable = false)
+    private String redirectedUrl; // 변환된 URL
+
+    @Column(name = "advertiser_id", length = 25, nullable = false)
+    private String advertiserId; // 광고주 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id", nullable = false)
+    private Contract contract; // 연결된 계약
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectLinks.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/RedirectLinks.java
@@ -11,7 +11,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 
-public class RedirectLink {
+public class RedirectLinks {
     @Id
     @Column(name = "redirect_id", length = 25, nullable = false)
     private String redirectId; // 리디렉션 링크 ID
@@ -22,8 +22,9 @@ public class RedirectLink {
     @Column(name = "redirected_url", columnDefinition = "LONGTEXT", nullable = false)
     private String redirectedUrl; // 변환된 URL
 
-    @Column(name = "advertiser_id", length = 25, nullable = false)
-    private String advertiserId; // 광고주 ID
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "advertiser_id", nullable = false)
+    private Advertiser advertiser;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "contract_id", nullable = false)

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Settlement.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Settlement.java
@@ -1,0 +1,50 @@
+package com.Gritty.Linki.entity;
+
+
+import com.Gritty.Linki.vo.enums.SettlementStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "settlement")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+public class Settlement {
+    @Id
+    @Column(name = "settlement_id", length = 25, nullable = false)
+    private String settlementId; // 정산 ID
+
+    @Column(name = "settlement_amount", precision = 15, scale = 2, nullable = false)
+    private BigDecimal settlementAmount; // 정산 금액
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "settlement_status", nullable = false)
+    private SettlementStatus settlementStatus; // 정산 상태 (PENDING, COMPLETED)
+
+    @Column(name = "settlement_date", nullable = false)
+    private LocalDate settlementDate; // 정산 예정일
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt; // 수정일시
+
+    // 🔗 연관 관계
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id", nullable = false)
+    private Contract contract; // 정산 대상 계약
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "influencer_id", nullable = false)
+    private Influencer influencer; // 정산 받는 인플루언서
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/Signature.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/Signature.java
@@ -1,0 +1,36 @@
+package com.Gritty.Linki.entity;
+
+import com.Gritty.Linki.vo.enums.SignatureStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "signature")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Signature {
+    @Id
+    @Column(name = "signature_id", length = 25, nullable = false)
+    private String signatureId; // 전자서명 기록 식별자
+
+    @Column(name = "signature_signer_name", length = 100)
+    private String signatureSignerName; // 서명자 이름
+
+    @Column(name = "signature_signed_at")
+    private LocalDateTime signatureSignedAt; // 서명 완료 시간
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "signature_status")
+    private SignatureStatus signatureStatus; // 서명 상태 (PARTIALLY_SIGNED, BOTH_SIGNED)
+
+    // 🔗 연관 관계
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_id", nullable = false)
+    private Contract contract; // 연관된 계약서
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/entity/User.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/entity/User.java
@@ -1,0 +1,49 @@
+package com.Gritty.Linki.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @Column(name = "user_id", length = 25, nullable = false)
+    private String userId; // UUID or 소셜 PK
+
+    @Column(name = "user_login_id", length = 20, nullable = false)
+    private String userLoginId; // 로그인 ID
+
+    @Column(name = "user_login_pw", length = 255, nullable = false)
+    private String userLoginPw; // 비밀번호
+
+    @Column(name = "user_name", length = 50, nullable = false)
+    private String userName; // 이름
+
+    @Column(name = "user_phone", length = 15, nullable = false)
+    private String userPhone; // 휴대폰 번호
+
+    @Column(name = "user_email", length = 255, nullable = false)
+    private String userEmail; // 이메일
+
+    @Column(name = "user_pay_status", nullable = false)
+    private Integer userPayStatus; // 결제 상태
+
+    @Column(name = "user_status", nullable = false)
+    private Integer userStatus; // 계정 활성/비활성 상태
+
+    @Column(name = "user_enter_day", nullable = false)
+    private LocalDate userEnterDay; // 가입일
+
+    @Column(name = "user_role", length = 20, nullable = false)
+    private String userRole; // 권한 (예: ROLE_USER, ROLE_ADMIN, 인플루언서, 광고주)
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/vo/enums/CampaignPublishStatus.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/vo/enums/CampaignPublishStatus.java
@@ -1,0 +1,5 @@
+package com.Gritty.Linki.vo.enums;
+
+public enum CampaignPublishStatus {
+    HIDDEN, ACTIVE
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/vo/enums/Category.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/vo/enums/Category.java
@@ -1,0 +1,6 @@
+package com.Gritty.Linki.vo.enums;
+
+public enum Category {
+    BEAUTY, FASHION, SPORTS, FOOD, VLOG, TRAVEL,
+    MUSIC, EDUCATION, ANIMAL, ELECTRONICS, ENTERTAINMENT
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/vo/enums/ContractStatus.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/vo/enums/ContractStatus.java
@@ -1,0 +1,8 @@
+package com.Gritty.Linki.vo.enums;
+
+public enum ContractStatus {
+    PENDING_SIGN, // 서명대기
+    CONFIRMED, // 계약완료
+    ONGOING, // 계약 진행중
+
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/vo/enums/ProposalStatus.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/vo/enums/ProposalStatus.java
@@ -1,0 +1,7 @@
+package com.Gritty.Linki.vo.enums;
+
+public enum ProposalStatus {
+    PENDING,   // 대기중
+    ACCEPTED,  // 수락됨
+    REJECTED   // 거절됨
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/vo/enums/SettlementStatus.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/vo/enums/SettlementStatus.java
@@ -1,0 +1,6 @@
+package com.Gritty.Linki.vo.enums;
+
+public enum SettlementStatus {
+    PENDING,    // 정산 대기
+    COMPLETED   // 정산 완료
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/vo/enums/SignatureStatus.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/vo/enums/SignatureStatus.java
@@ -1,0 +1,6 @@
+package com.Gritty.Linki.vo.enums;
+
+public enum SignatureStatus {
+    PARTIALLY_SIGNED, // 한 명만 서명 완료
+    BOTH_SIGNED        // 양쪽 모두 서명 완료
+}


### PR DESCRIPTION
### 📌 작업 내용
광고주/인플루언서 엔티티 초기 세팅 

### ✅ 작업 항목
-광고주, 광고주리뷰, 캠페인, 채널, 채널상세, 계약, 인플루언서, 인플루언서 인증, 인플루언서 리뷰, 제안서, 리다이렉트 링크, 리다이렉트 클릭, , 정산, 서명, 유저 엔티티 생성 완료

-enum 클래스 정의 

### 💬 참고
예상되는 영향이나 고민
