### PR TITLE
✨ feature :  광고주 채팅기능 백엔드 구현 

### DIFF
--- a/chat-service/src/main/java/com/ssg/chatservice/client/ChatApiClient.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/client/ChatApiClient.java
@@ -9,7 +9,7 @@
 
     @FeignClient(name="chatInfo-api",url="http://localhost:8080")
     public interface ChatApiClient {
-        @GetMapping("/v1/integration-service/api/chat/{id}")
+        @GetMapping("/v1/integration-service/api/chatInfo/{id}")
         List<ChatInfoResponse> getChatInfo(
                 @RequestHeader("Authorization") String authorization,
                 @PathVariable("id") String campaign);

--- a/chat-service/src/main/java/com/ssg/chatservice/config/security/JwtFilter.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/config/security/JwtFilter.java
@@ -19,23 +19,21 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+//jwt 검증 필터
 public class JwtFilter extends OncePerRequestFilter {
-
     private final JwtUtil jwtUtil;
-
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
-
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String authorization = request.getHeader("Authorization");
 
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            log.info("인증 헤더 없음");
+        //헤더 토큰 확인
+        if(authorization == null || !authorization.startsWith("Bearer ")) {
+            log.info("인증헤더 없어");
             filterChain.doFilter(request, response);
             return;
         }
 
+        //베리어 제거
         String token = authorization.split(" ")[1];
 
         if (jwtUtil.isTokenExpired(token)) {
@@ -44,14 +42,16 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
+
         String userId = jwtUtil.getUserId(token);
         String role = jwtUtil.getRole(token);
+        log.debug("role in token = {}", role);
 
         // Authentication 객체 생성 및 등록
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 userId,
                 null,
-                List.of(new SimpleGrantedAuthority("ROLE_" + role)) // ROLE_ prefix 필수
+                List.of(new SimpleGrantedAuthority(role))
         );
 
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/chat-service/src/main/java/com/ssg/chatservice/domain/chat/controller/ChatController.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/domain/chat/controller/ChatController.java
@@ -10,10 +10,7 @@ import com.ssg.chatservice.domain.chat.service.ChatServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,9 +26,10 @@ public class ChatController {
     private final PartnerApiClient partnerApiClient;  // PartnerApiClient 주입
 
     // 제안서 아이디를 받아 채팅방 생성 후 채팅방 아이디 반환
+    //TODO: string -> DTO 반환으로 변경 (프론트 수정 필요)
     @PostMapping("/influencer/rooms/{proposalId}")
-    public String createRoom(@RequestBody String proposalId){
-        return  chatService.createRoom(proposalId);
+    public ChatResponeDTO createRoom(@PathVariable String proposalId){
+        return  modelMapper.map(chatService.createRoom(proposalId),ChatResponeDTO.class);
     }
 
     //TODO : 토큰 전달을 직접하지 않고, jwtutil 사용하여 클라이언트 서비스에서 새로 생성할 것
@@ -39,8 +37,7 @@ public class ChatController {
     @GetMapping("/influencer/room/{proposalId}")
     public ChatDetailResponeDTO enterRoomByProposal(@PathVariable String proposalId,
                                                     @RequestHeader("Authorization") String authorizationHeader){
-        ChatDetailDTO chatDetailDTO = chatService.findByProposalId(authorizationHeader, proposalId);
-        return modelMapper.map(chatDetailDTO, ChatDetailResponeDTO.class);
+        return modelMapper.map( chatService.getChatDtoByProposalId(authorizationHeader, proposalId), ChatDetailResponeDTO.class);
     }
 
     //광고주의 채팅목록 조회
@@ -51,6 +48,23 @@ public class ChatController {
         }).collect(Collectors.toList());
     }
 
+    //광고주의 제안서 수락 시 채팅방 활성화
+    @PostMapping("/advertiser/rooms/activate/{proposalId}")
+    public ChatResponeDTO activateRoomByProposal(@PathVariable String proposalId){
+        return modelMapper.map(chatService.activateRoomByProposal(proposalId),ChatResponeDTO.class);
+    }
 
-    
+    //광고주가 채팅목록에서 특정 채팅방 조회
+    @GetMapping("/advertiser/chat-detail/{chatId}")
+    public ChatDetailResponeDTO chatRoomByCampign(@RequestHeader("Authorization")String token,@PathVariable String chatId){
+        return modelMapper.map(chatService.getChatDtoByChatId(token,chatId),ChatDetailResponeDTO.class);
+    }
+
+    //광고주의 제안서 거절 시 채팅방 소프트 삭제
+    @PostMapping("/advertiser/proposals/{proposalId}/reject")
+    public ChatResponeDTO rejectProposal(@PathVariable String proposalId){
+        return modelMapper.map(chatService.softDeleteChat(proposalId),ChatResponeDTO.class);
+    }
+
+
 }

--- a/chat-service/src/main/java/com/ssg/chatservice/domain/chat/dto/ChatDTO.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/domain/chat/dto/ChatDTO.java
@@ -1,13 +1,12 @@
 package com.ssg.chatservice.domain.chat.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
-@Setter
-@Getter
+@Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ChatDTO {
     private String chatId;
     private String opponentId;

--- a/chat-service/src/main/java/com/ssg/chatservice/domain/chat/dto/respone/ChatResponeDTO.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/domain/chat/dto/respone/ChatResponeDTO.java
@@ -1,14 +1,14 @@
 package com.ssg.chatservice.domain.chat.dto.respone;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Setter
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ChatResponeDTO {
     private String chatId;
     private String opponentId;

--- a/chat-service/src/main/java/com/ssg/chatservice/domain/chat/enums/ErrorCode.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/domain/chat/enums/ErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     CHATROOM_ALREADY_EXIST(HttpStatus.CONFLICT,"이미 존재하는 채팅방 입니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "메세지가 존재하지 않습니다."),
     PARTNER_API_FAILED(HttpStatus.BAD_GATEWAY, "파트너 API 호출에 실패했습니다."),
     JWT_TOKEN_END(HttpStatus.UNAUTHORIZED,"토큰 만료"),
     JWT_TOKEN_FAIL(HttpStatus.UNAUTHORIZED,"토큰 인증 불가");

--- a/chat-service/src/main/java/com/ssg/chatservice/domain/chat/service/ChatService.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/domain/chat/service/ChatService.java
@@ -3,6 +3,7 @@ package com.ssg.chatservice.domain.chat.service;
 import com.ssg.chatservice.client.ChatInfoResponse;
 import com.ssg.chatservice.domain.chat.dto.ChatDTO;
 import com.ssg.chatservice.domain.chat.dto.ChatDetailDTO;
+import com.ssg.chatservice.domain.chat.dto.respone.ChatDetailResponeDTO;
 import com.ssg.chatservice.domain.message.dto.ChatMessageDTO;
 import com.ssg.chatservice.entity.Chat;
 
@@ -11,10 +12,13 @@ import java.util.Map;
 
 public interface ChatService {
 
-    //제안서 아이디로 채팅방 조회
-    ChatDetailDTO findByProposalId(String token,String proposalId);
+
+    //제안서아이디로  채팅방 조회
+    Chat findByProposalId(String proposalId);
+    //제안서 아이디로 ChatDetailDTO 반환
+    ChatDetailDTO getChatDtoByProposalId(String token,String proposalId);
     //제안서 아이디로 채팅방 생성
-    String createRoom(String proposalId);
+    ChatDTO createRoom(String proposalId);
     //캠페인 아이디로 채팅 정보 조회
     List<ChatInfoResponse> chatInfoResponses(String token, String campaignId);
     //채팅 정보로 채팅방 조회
@@ -23,4 +27,10 @@ public interface ChatService {
     List<ChatDTO> chatDTOs (List<Chat> chats ,List<ChatInfoResponse> chatInfos,Map<String, ChatMessageDTO> lastMessages);
     //캠페인 아이디로 채팅목록 조회
     List<ChatDTO> campaignToChatList(String token, String campaignId);
+    //제안서에 해당하는 채팅방 상태를 활성으로 변경
+    Chat activateRoomByProposal(String proposalId);
+    //채팅아이디로 채팅방 조회
+    ChatDetailDTO getChatDtoByChatId(String token,String chatId);
+    //제안서에 해당하는 채팅방 소프트삭제
+    Chat softDeleteChat(String proposalId);
 }

--- a/chat-service/src/main/java/com/ssg/chatservice/domain/message/service/MessageServiceImpl.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/domain/message/service/MessageServiceImpl.java
@@ -1,9 +1,11 @@
 package com.ssg.chatservice.domain.message.service;
 
+import com.ssg.chatservice.domain.chat.enums.ErrorCode;
 import com.ssg.chatservice.domain.message.dto.ChatMessageDTO;
 import com.ssg.chatservice.domain.message.repository.MessageRepository;
 import com.ssg.chatservice.entity.Chat;
 import com.ssg.chatservice.entity.Message;
+import com.ssg.chatservice.exception.ChatException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -41,11 +43,16 @@ public class MessageServiceImpl implements MessageService{
     //메세지 테이블에서 마지막 메세지 조회(DateType 변환을 위해 DTO로 변환)
     public Map<String,ChatMessageDTO> lastMessage(List<Chat> chats){
         Map<String,ChatMessageDTO> lastMessageMap = new HashMap<>();
+        try {
         chats.stream().forEach(chat -> {
             Message lastMessage = messageRepository.findTop1ByChatIdOrderByMessageDateDesc(chat.getChatId());
-            ChatMessageDTO chatLastMessageDTO = modelMapper.map(lastMessage,ChatMessageDTO.class);
-            lastMessageMap.put(chat.getChatId(),chatLastMessageDTO);
+
+               ChatMessageDTO chatLastMessageDTO = modelMapper.map(lastMessage, ChatMessageDTO.class);
+               lastMessageMap.put(chat.getChatId(), chatLastMessageDTO);
         });
+        }catch (Exception  e){
+            throw new ChatException(ErrorCode.MESSAGE_NOT_FOUND);
+        }
         return lastMessageMap;
     }
 

--- a/chat-service/src/main/java/com/ssg/chatservice/entity/Message.java
+++ b/chat-service/src/main/java/com/ssg/chatservice/entity/Message.java
@@ -25,18 +25,16 @@ public class Message{
         return IdGenerator.messageId();
     }
 
-    @Field("chat_id")
     private String chatId;
-    @Field("message_content")
+
     private String messageContent;
     //mongoDB의 date
-    @Field("message_date")
     private Instant messageDate;
-    @Field("message_read")
+
     private boolean messageRead;
-    @Field("message_sender_id")
+
     private String messageSenderId;
-    @Field("message_type")
+
     private String messageType;
 
     public void initializeIdIfNull() {

--- a/chat-service/src/test/java/com/ssg/chatservice/domain/chat/service/ChatServiceImplTest.java
+++ b/chat-service/src/test/java/com/ssg/chatservice/domain/chat/service/ChatServiceImplTest.java
@@ -1,19 +1,29 @@
 package com.ssg.chatservice.domain.chat.service;
 
-import com.ssg.chatservice.client.PartnerApiClient;
-import com.ssg.chatservice.client.PartnerInfoResponse;
+import com.ssg.chatservice.client.ChatInfoResponse;
+import com.ssg.chatservice.domain.chat.dto.ChatDTO;
+import com.ssg.chatservice.domain.chat.dto.ChatDetailDTO;
+import com.ssg.chatservice.domain.chat.enums.ChatStatus;
 import com.ssg.chatservice.domain.chat.repository.ChatRepository;
+import com.ssg.chatservice.domain.message.dto.ChatMessageDTO;
+import com.ssg.chatservice.domain.message.service.MessageService;
 import com.ssg.chatservice.entity.Chat;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.BDDMockito.given;
-
+@Slf4j
 @SpringBootTest
 class ChatServiceImplTest {
 
@@ -23,40 +33,152 @@ class ChatServiceImplTest {
     @Autowired
     private ChatRepository chatRepository;
 
-    @MockBean // 외부 API 클라이언트는 실제 호출하지 않고 가짜 객체로 대체
-    private PartnerApiClient partnerApiClient;
-
     @Autowired
     private ModelMapper modelMapper;
 
+    @Autowired
+    private MessageService messageService;
+
     @Test
-    @DisplayName("createRoom() - 채팅방 생성 성공 및 응답 DTO 검증")
-    void createChatRoomTest() {
-        // 테스트에 사용할 제안서 ID 정의
-        String proposalId = "test1977";
-
-        // PartnerApiClient가 반환할 가짜 파트너 정보 정의
-        PartnerInfoResponse fakePartner = new PartnerInfoResponse(
-                "partnerId",
-                "partnerName",
-                "test1977",
-                "profile.png",
-                "채널명",
-                "PENDING");
-        //토큰 전달
-        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJVU0VSMDAwMCIsInVzZXJSb2xlIjoiUk9MRV9JTkZMVUVOQ0VSIiwiaWF0IjoxNzUwMjA5Mjg0LCJleHAiOjE3NTAyNDUyODR9.kJwCO-Wd4jsJ8HlpnHbAtiFP0zkgvatyP5vivupRbDk";
-        //제안서 ID로 partner API 호출 시 위 데이터를 반환하도록 mock 세팅
-        given(partnerApiClient.getPartnerInfo(token,proposalId)).willReturn(fakePartner);
-
-        // 채팅방 생성 로직 실행
-        String result = chatService.createRoom(proposalId);
-
-        //  반환된 DTO가 null이 아니고, 제안서 ID가 일치하는지 검증
-        assertThat(result).isNotNull();
-
-        //  DB에 채팅방이 실제로 저장되었는지 확인
-        Chat saved = chatRepository.findByProposalId(proposalId);
-        assertThat(saved).isNotNull(); // DB에 저장 여부
-        assertThat(saved.getProposalId()).isEqualTo(proposalId); // 제안서 ID 일치
+    @DisplayName("제안서 아이디로 채팅방 조회")
+    void findByProposalId(){
+        String proposalId = "PRP-0000000000000000";
+        Chat chat = chatService.findByProposalId(proposalId);
+        assertThat(chat).isNotNull();
+        assertThat(chat.getProposalId()).isEqualTo(proposalId);
     }
+
+
+    @Test
+    @DisplayName("제안서 아이디로 ChatDetailDTO 조회")
+    void getChatDtoByProposalId() {
+        // 테스트에 사용할 제안서 ID 정의
+        String proposalId = "PRP-0000000000000000";
+
+        // 토큰 전달
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJVU1ItMDAwMDAwMDAwMDAwMDAwMCIsInVzZXJSb2xlIjoiUk9MRV9JTkZMVUVOQ0VSIiwiaWF0IjoxNzUwMzg3NjQ2LCJleHAiOjE3NTA0MjM2NDZ9.zI8qCp_QrrKF7cYIBAdMuHPi1ht5uyS_pqWgEwdqf88";
+
+        //파트너 객체 호출
+        ChatDetailDTO chatDetailDTO = chatService.getChatDtoByProposalId(token, proposalId);
+        //반환된 DTO가 null이 아니고, 제안서 ID가 일치하는지 검증
+        assertThat(chatDetailDTO).isNotNull();
+        assertThat(chatDetailDTO.getProposalId()).isEqualTo(proposalId);
+    }
+
+    //채팅방이 없는 제안서 아이디로 test 시 성공
+    @Test
+    @DisplayName("채팅방 생성")
+    void createRoom(){
+        ChatDTO chat = chatService.createRoom("PRP-000000000000000");
+
+        assertThat(chat).isNotNull();
+        assertThat(chat.getProposalId()).isEqualTo("PRP-000000000000000");
+    }
+
+    @Test
+    @DisplayName("광고주의 채팅 목록 조회 (캠페인 아이디로 채팅방 조회)")
+    void campaignToChatList(){
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJVU1ItMDAwMDAwMDAwMDAwMDAwMiIsInVzZXJSb2xlIjoiUk9MRV9BRFZFUlRJU0VSIiwiaWF0IjoxNzUwNDA3MTgzLCJleHAiOjE3NTA0NDMxODN9.jjojs_8C3b36deWJgFFijvtCAru-1JpodxuWxvqi204";
+        String campaignId = "CMP-0000000000000000";
+
+        List<ChatDTO> chatDTOs = chatService.campaignToChatList(token,campaignId);
+
+        chatDTOs.forEach(chatDTO -> log.info("chatDTO={}",chatDTO.toString()));
+
+
+    }
+
+
+
+    @Test
+    @DisplayName("캠페인 아이디로 ChatInfoResponse 조회")
+    void chatInfoResponses(){
+        // 테스트에 사용할 캠페인 ID 정의
+        String campaignId = "CMP-0000000000000000";
+
+        // 토큰 전달
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJVU1ItMDAwMDAwMDAwMDAwMDAwMCIsInVzZXJSb2xlIjoiUk9MRV9JTkZMVUVOQ0VSIiwiaWF0IjoxNzUwMzg3NjQ2LCJleHAiOjE3NTA0MjM2NDZ9.zI8qCp_QrrKF7cYIBAdMuHPi1ht5uyS_pqWgEwdqf88";
+
+        //파트너 객체 호출
+        List<ChatInfoResponse> chatInfoResponses = chatService.chatInfoResponses(token, campaignId);
+        //반환된 DTO가 null이 아니고, 제안서 ID가 일치하는지 검증
+        assertThat(chatInfoResponses).isNotNull();
+        log.info(chatInfoResponses.toString());
+
+    }
+
+    @Test
+    @DisplayName("채팅 정보리스트에서 proposalId 추출하여 채팅방 조회")
+    void chatInfoGetChat(){
+        List<ChatInfoResponse> chatInfoResponses = List.of(
+                new ChatInfoResponse("test1", "test1", "PRP-0000000000000000"),
+                new ChatInfoResponse("test2", "test2", "PRP-0000000000000001")
+        );
+
+        List<Chat> chats = chatService.chatInfoGetChat(chatInfoResponses);
+        List<String> proposalIds = chats.stream().map(Chat::getProposalId).collect(Collectors.toList());
+        proposalIds.forEach(poposalId -> log.info("proposalId={}",poposalId));
+    }
+
+    @Test
+    @DisplayName("chatDto List 빌더")
+    void chatDTOs(){
+        List<Chat> chats = List.of(
+                new Chat("CHT-0000000000000000", Instant.now(), ChatStatus.PENDING,"PRP-000000000000000"),
+                new Chat("CHT-0000000000000001", Instant.now(), ChatStatus.PENDING,"PRP-0000000000000001")
+        );
+        List<ChatInfoResponse> chatInfoResponses = List.of(
+                new ChatInfoResponse("test1", "test1", "PRP-0000000000000000"),
+                new ChatInfoResponse("test2", "test2", "PRP-0000000000000001")
+        );
+
+        Map<String, ChatMessageDTO> lastMessages = Map.of(
+                "CHT-0000000000000000",new ChatMessageDTO("MSG-test1","CHT-0000000000000000","user-test","CHT-0000000000000000의 마지막메시지","TEXT",LocalDateTime.now(),false),
+                "CHT-0000000000000001",new ChatMessageDTO("MSG-test2","CHT-0000000000000001","user-test","CHT-0000000000000001의 마지막메시지","TEXT",LocalDateTime.now(),false)
+        );
+
+        List<ChatDTO> chatDTOs = chatService.chatDTOs(chats,chatInfoResponses,lastMessages);
+        chatDTOs.forEach(chatDTO -> log.info("chatDTO={}",chatDTO.toString()));
+
+
+    }
+
+    @Test
+    @DisplayName("제안서에 해당하는 채팅방 상태를 활성으로 변경")
+    void activateRoomByProposal(){
+        Chat beforeChat = chatService.findByProposalId("PRP-0000000000000000");
+        log.info(String.valueOf(beforeChat.getChatStatus()));
+
+        chatService.activateRoomByProposal("PRP-0000000000000000");
+        Chat AfterChat = chatService.findByProposalId("PRP-0000000000000000");
+        log.info(String.valueOf(AfterChat.getChatStatus()));
+        assertThat(AfterChat.getChatStatus()).isEqualTo(ChatStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("채팅아이디로 채팅방 조회")
+    void getChatDtoByChatId(){
+        // 토큰 전달
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJVU1ItMDAwMDAwMDAwMDAwMDAwMCIsInVzZXJSb2xlIjoiUk9MRV9JTkZMVUVOQ0VSIiwiaWF0IjoxNzUwMzg3NjQ2LCJleHAiOjE3NTA0MjM2NDZ9.zI8qCp_QrrKF7cYIBAdMuHPi1ht5uyS_pqWgEwdqf88";
+        String chatId = "CHT-0000000000000000";
+        ChatDetailDTO chat = chatService.getChatDtoByChatId(token,chatId);
+
+        log.info("ChatDetailDTO = {}",chat.toString());
+
+        assertThat(chat).isNotNull();
+        assertThat(chat.getChatId()).isEqualTo(chatId);
+    }
+
+    @Test
+    @DisplayName("제안서에 해당하는 채팅방 소프트삭제")
+    void softDeleteChat(){
+        Chat beforeChat = chatService.findByProposalId("PRP-0000000000000000");
+        log.info(String.valueOf(beforeChat.getChatStatus()));
+
+        chatService.activateRoomByProposal("PRP-0000000000000000");
+        Chat AfterChat = chatService.softDeleteChat("PRP-0000000000000000");
+        log.info(String.valueOf(AfterChat.getChatStatus()));
+        assertThat(AfterChat.getChatStatus()).isEqualTo(ChatStatus.DELETE);
+    }
+
 }

--- a/integration-service/src/main/java/com/Gritty/Linki/client/chatClient/ChatInfoResponse.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/client/chatClient/ChatInfoResponse.java
@@ -1,0 +1,14 @@
+package com.Gritty.Linki.client.chatClient;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatInfoResponse {
+    private String opponentId;
+    private String opponentName;
+    private String proposalId;
+}

--- a/integration-service/src/main/java/com/Gritty/Linki/client/chatClient/DummyChatInfoController.java
+++ b/integration-service/src/main/java/com/Gritty/Linki/client/chatClient/DummyChatInfoController.java
@@ -1,0 +1,20 @@
+package com.Gritty.Linki.client.chatClient;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/integration-service/api/chatInfo")
+public class DummyChatInfoController {
+
+    @GetMapping("/{id}")
+    public List<ChatInfoResponse> getChatInfo(@PathVariable String id) {
+        return  List.of(
+                new ChatInfoResponse("test1", "test1", "PRP-0000000000000002"),
+                new ChatInfoResponse("test2", "test2", "PRP-0000000000000003")
+        );
+    }
+}

--- a/quries/Message.mongo.js
+++ b/quries/Message.mongo.js
@@ -31,12 +31,12 @@ for (let seq = 0; seq < 5000; seq++) {
 
     messages.push({
         _id: "MSG-" + seq.toString().padStart(16, '0'),
-        chat_id: "CHA-" + Math.floor(seq / 5).toString().padStart(16, '0'),
-        message_sender_id: "USER-" + Math.floor(Math.random() * 1500).toString().padStart(15, '0'),
-        message_content: "메시지 내용" + seq,
-        message_type: ["TEXT", "IMAGE", "FILE"][Math.floor(Math.random() * 3)],
-        message_date: randomDate,
-        message_read: Math.random() < 0.5
+        chatId: "CHT-" + Math.floor(seq / 5).toString().padStart(16, '0'),
+        messageSenderId: "USER-" + Math.floor(Math.random() * 1500).toString().padStart(15, '0'),
+        messageContent: "메시지 내용" + seq,
+        messageType: ["TEXT", "IMAGE", "FILE"][Math.floor(Math.random() * 3)],
+        messageDate: randomDate,
+        messageRead: Math.random() < 0.5
     });
 }
 


### PR DESCRIPTION
### 📌 작업 내용
광고주의 채팅기능 백엔드 구현 및 단위테스트 

### ✅ 작업 항목
- 채팅목록조회 DTO/REPO/SERVICE/CONROLLER 구현 및 테스트 
- 광고주가 선택한 채팅방입장 DTO/REPO/SERVICE/CONROLLER 구현 및 테스트 
- 제안서 수락 시 (채팅방 활성으로 상태 변경 , 해당 채팅방으로 이동)구현 및 테스트 
- 거절 시 채팅방 소프트 삭제 구현 및 테스트 

### 💬 참고
[](url
[ChatController.postman_test_run.json](https://github.com/user-attachments/files/20834160/ChatController.postman_test_run.json)
[MessageCollection.postman_test_run.json](https://github.com/user-attachments/files/20834163/MessageCollection.postman_test_run.json)
